### PR TITLE
Feat(zotero): naming style of Zotero items' page title

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -119,6 +119,9 @@ logseq
       key: 'alias_citationKey',
       type: 'boolean',
       default: false,
+      title: 'Option (Experimental): BetterBibTeX citationKey as page alias',
+      description: 'If you use [BetterBibTeX](https://github.com/retorquere/zotero-better-bibtex), this option adds `alias:: citationKey` to the page created. Also, `[[citationKey]]` will inserted at cursor, instead of `[[@___]]`. (Recommend: off)',
+    },
     {
       key: 'title_zotero_basename',
       type: 'boolean',

--- a/src/main.js
+++ b/src/main.js
@@ -119,8 +119,12 @@ logseq
       key: 'alias_citationKey',
       type: 'boolean',
       default: false,
-      title: 'Option (Experimental): use BetterBibTeX citationKey as page alias',
-      description: 'If you use [BetterBibTeX](https://github.com/retorquere/zotero-better-bibtex), you can choose `citationKey` as page alias. Search importation is also affected: `[[citationKey]]` will be used when importing items at cursor. (Recommend: off)',
+    {
+      key: 'title_zotero_basename',
+      type: 'boolean',
+      default: false,
+      title: 'Option (Experimental): enable the Zotero-style title',
+      description: 'Use the Zotero File Renaming rule (see the template in [Zotero tutorial](https://www.zotero.org/support/file_renaming)) to name the page `@___`. (Recommend: off)',
     },
     {
       key: 'unwanted_keys',

--- a/src/zotero/item.ts
+++ b/src/zotero/item.ts
@@ -15,7 +15,7 @@ export class ZoteroItem {
   // @arg raw: raw data from Zotero API (Zapi)
   static fromRaw(rawData: any): ZoteroItem {
 
-    let { item: raw, attachments, citationKey } = rawData;
+    let { item: raw, attachments, citationKey, aux } = rawData;
 
     // It might change accordingly if the return format of Zapi changes
 
@@ -35,7 +35,7 @@ export class ZoteroItem {
     let zoteroItem = new ZoteroItem();
     zoteroItem.raw = raw
     zoteroItem.key = raw.key;
-    zoteroItem.page = Page.fromRaw(raw);
+    zoteroItem.page = Page.fromRaw(raw, aux);
     return zoteroItem
   }
 
@@ -147,10 +147,7 @@ export class ZoteroItems {
 
   static fromRaw(rawData: any[]) {
     // check if rawData is an array or similiar
-
-    let zoteroItems = new ZoteroItems();
-    zoteroItems.items = rawData.map((item: any) => ZoteroItem.fromRaw(item));
-    return zoteroItems;
+    return new ZoteroItems(rawData.map((item: any) => ZoteroItem.fromRaw(item)));
   }
 
   add(item: ZoteroItem) {


### PR DESCRIPTION
#12 :
- [x] ZoteroItem: add api `getBasename()` providing fileBasename
- [ ] zotserver:  include `fileBasename` property in response
- [ ] settings option (tick on/off): overiding the default tnaming style by using `fileBasename` provided by Zotero